### PR TITLE
add command line flags 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,3 @@ module github.com/DimitarPetrov/godoc-generate
 go 1.17
 
 require github.com/dave/dst v0.26.2
-
-require (
-	golang.org/x/tools v0.0.0-20200509030707-2212a7e161a5 // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
-)

--- a/main.go
+++ b/main.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
-	"github.com/dave/dst"
-	"github.com/dave/dst/decorator"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -13,16 +12,24 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
 )
 
-const godocCommentFormat = "// %s missing godoc"
+var godocCommentFormat = "// %s missing godoc"
+var godocAllowNoSpace = false
 
 func main() {
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Fatalf("error getting current working directory: %v", err)
 	}
-
+	commentFormat := flag.String("format", "// %s missing godoc", "comment format")
+	allowNoSpace := flag.Bool("allow_no_space", false, "allow comments without space between // and type name")
+	flag.Parse()
+	godocCommentFormat = *commentFormat
+	godocAllowNoSpace = *allowNoSpace
 	log.Print(fmt.Sprintf("Adding default go doc to each exported type/func recursively in %s", wd))
 
 	if err := mapDirectory(wd, instrumentDir); err != nil {
@@ -112,7 +119,8 @@ func instrumentFile(fset *token.FileSet, file *ast.File, out io.Writer) error {
 
 func containsGoDoc(decs []string, name string) bool {
 	for _, dec := range decs {
-		if strings.HasPrefix(dec, "// "+name) {
+		if strings.HasPrefix(dec, "// "+name) ||
+			(godocAllowNoSpace && strings.HasPrefix(dec, "//"+name)) {
 			return true
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -17,19 +17,21 @@ import (
 	"github.com/dave/dst/decorator"
 )
 
-var godocCommentFormat = "// %s missing godoc."
-var godocAllowNoSpace = false
+const defaultGodocCommentFormat = "// %s missing godoc."
+
+var godocCommentFormat string
+
+func init() {
+	flag.StringVar(&godocCommentFormat, "format", defaultGodocCommentFormat, "comment format")
+	flag.Parse()
+}
 
 func main() {
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Fatalf("error getting current working directory: %v", err)
 	}
-	commentFormat := flag.String("format", "// %s missing godoc", "comment format")
-	allowNoSpace := flag.Bool("allow_no_space", false, "allow comments without space between // and type name")
-	flag.Parse()
-	godocCommentFormat = *commentFormat
-	godocAllowNoSpace = *allowNoSpace
+
 	log.Print(fmt.Sprintf("Adding default go doc to each exported type/func recursively in %s", wd))
 
 	if err := mapDirectory(wd, instrumentDir); err != nil {
@@ -119,8 +121,7 @@ func instrumentFile(fset *token.FileSet, file *ast.File, out io.Writer) error {
 
 func containsGoDoc(decs []string, name string) bool {
 	for _, dec := range decs {
-		if strings.HasPrefix(dec, "// "+name) ||
-			(godocAllowNoSpace && strings.HasPrefix(dec, "//"+name)) {
+		if strings.HasPrefix(dec, "// "+name) || strings.HasPrefix(dec, "//"+name) {
 			return true
 		}
 	}


### PR DESCRIPTION
add command line flags  to modify the comment text and to allow comments without leading spaces